### PR TITLE
Alterar URL da biblioteca de javascript do Masterpass

### DIFF
--- a/src/main/resources/public/html/index2.html
+++ b/src/main/resources/public/html/index2.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<script type="text/javascript" src="https://sandbox.static.masterpass.com/integration/merchant.js"></script>
+		<script type="text/javascript" src="https://sandbox.masterpass.com/integration/merchant.js"></script>
 	</head>
 	<body>
 		<p class="message"></p>

--- a/src/main/resources/templates/express.vm
+++ b/src/main/resources/templates/express.vm
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<script type="text/javascript" src="https://sandbox.static.masterpass.com/integration/merchant.js"></script>
+		<script type="text/javascript" src="https://sandbox.masterpass.com/integration/merchant.js"></script>
 	</head>
 	<body>
 		<p class="message"></p>

--- a/src/main/resources/templates/index.vm
+++ b/src/main/resources/templates/index.vm
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<script type="text/javascript" src="https://sandbox.static.masterpass.com/integration/merchant.js"></script>
+		<script type="text/javascript" src="https://sandbox.masterpass.com/integration/merchant.js"></script>
 	</head>
 	<body>
 		<p class="message"></p>


### PR DESCRIPTION
Anteriormente a biblioteca javascript do Masterpass estava disponível no endereço: `https://sandbox.static.masterpass.com/integration/merchant.js`

Agora está disponível neste novo endereço, conforme [documentação](https://developer.mastercard.com/documentation/masterpass-merchant-integration-v7): `https://sandbox.masterpass.com/integration/merchant.js`

Neste pull request fiz a alteração dos três locais que utilizam essa lib.